### PR TITLE
Expand the multi_json gem dependency range up to 1.10.1

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty')
-  spec.add_dependency('multi_json', '~> 1.9.2')
+  spec.add_dependency('multi_json', '~> 1.10', '>= 1.10.1')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty')
-  spec.add_dependency('multi_json', '~> 1.10', '>= 1.10.1')
+  spec.add_dependency('multi_json', '>= 1.9.2', '<= 1.10.1')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Expands the [multi_json](https://rubygems.org/gems/multi_json) gem dependency version up to the most recent version 1.10.1 (was 1.9 only)

A lot of gems have dependency on multi_json so in order to avoid conflicts it'd be good to keep the range of versions either as high and/or as wide as possible.  

In this case, greenhouse_io is the only gem dependency my codebase has which still depends on multi_json 1.9

Tests are passing, let me know if there's anything else I can do! 

Thank you